### PR TITLE
Improve test reliability by cleaning the state after running test_11_log_file

### DIFF
--- a/tests/unittests/test_00_initialization.py
+++ b/tests/unittests/test_00_initialization.py
@@ -138,6 +138,7 @@ def test_11_log_file(capsys):
         assert(s.name == 's')
         assert(len(s.handlers) == 1)
         assert(len(f.handlers) >= 1)
+        s.handlers = []
 # End test_11_log_file
 
 


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_11_log_file` by cleaning the state after running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/unittests/test_00_initialization.py::test_11_log_file`.
```
>           assert(len(s.handlers) == 1)
E           assert 2 == 1
E            +  where 2 = len([<StreamHandler <stderr> (INFO)>, <StreamHandler <stderr> (INFO)>])
E            +    where [<StreamHandler <stderr> (INFO)>, <StreamHandler <stderr> (INFO)>] = <Logger s (WARNING)>.handlers
===== 1 failed, 1 passed in 0.33s=====
```
More specifically, this PR cleans the post-state by resetting `s.handlers` to an empty list. In this way, the test does not fail on the second run any more.

It may be better to avoid state pollutions so that some other tests won't fail in the future due to the shared state pollution.
